### PR TITLE
CB-22381: store event names for unprocessed messages

### DIFF
--- a/transport/Transport.js
+++ b/transport/Transport.js
@@ -52,7 +52,7 @@ export default class Transport {
          * processed by any listener. They are later passed on every new
          * listener until they are processed.
          *
-         * @type {Set<Object>}
+         * @type {Set<CachedEventTuple>}
          */
         this._unprocessedMessages = new Set();
 

--- a/transport/Transport.js
+++ b/transport/Transport.js
@@ -5,6 +5,13 @@ import {
 } from './constants.js';
 
 /**
+ * [VOWEL] TODO push upstream
+ * @typedef {Object} CachedEventTuple
+ * @property {string} eventName - The name of the event.
+ * @property {Object[]} args - The event argument to be passed to the listener.
+ */
+
+/**
 * Stores the currnet transport backend that have to be used. Also implements
 * request/response mechanism.
 */
@@ -130,7 +137,8 @@ export default class Transport {
         }
 
         if (!isProcessed) {
-            this._unprocessedMessages.add(args);
+            // [VOWEL] store eventName to avoid errors
+            this._unprocessedMessages.add({ eventName, args });
         }
 
         return isProcessed;
@@ -155,8 +163,9 @@ export default class Transport {
 
         listenersForEvent.add(listener);
 
-        this._unprocessedMessages.forEach(args => {
-            if (listener(...args)) {
+        // [VOWEL] Use the eventName to call only the listeners which registered for that specific event.
+        this._unprocessedMessages.forEach(({ eventName: unprocessedEventName, args }) => {
+            if (unprocessedEventName === eventName && listener(...args)) {
                 this._unprocessedMessages.delete(args);
             }
         });


### PR DESCRIPTION
Store the event name for unprocessed messages and call only the listeners which have registered to that specific event name.

## Description of the change

> Description here

## Type of change
- [x] The JIRA ticket referenced in this pull request is marked appropriately as Feedback Issue/Bug (non-breaking change that fixes an issue), or Story (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that requires changes in other repositories to function)
- [ ] This change requires a documentation update on the Wiki.

## Checklists

### Development and Testing

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All linting rules and tests pass, indicated by the Continuous Integration build system status.

### Code review 

- [ ] This pull request is using the issue tracker (JIRA) ID in the title, branch name, and commit message so that the issue tracker matches the link automatically. The issue tracker is also used to track related issues.
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand, complex or unintuitive areas.